### PR TITLE
Generate .cljs.edn file to fix unecesary compilation and loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .nrepl-*
 
 project.clj
+.idea

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CI](https://circleci.com/gh/crisptrutski/boot-cljs-test.svg?style=svg)](https://
 
 [](dependency)
 ```clojure
-[crisptrutski/boot-cljs-test "0.2.1"] ;; latest release
+[crisptrutski/boot-cljs-test "0.2.2-SNAPSHOT"] ;; latest release
 ```
 [](/dependency)
 

--- a/build.boot
+++ b/build.boot
@@ -10,7 +10,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[adzerk.boot-test :refer :all])
 
-(def +version+ "0.2.1")
+(def +version+ "0.2.2-SNAPSHOT")
 
 (bootlaces! +version+)
 

--- a/src/crisptrutski/boot_cljs_test.clj
+++ b/src/crisptrutski/boot_cljs_test.clj
@@ -61,11 +61,15 @@
    s suite-ns   NS  sym       "Test entry point. If this is not provided, a namespace will be
                                generated."]
   (let [out-file (or out-file default-output)
+        out-id   (str/replace out-file #"\.js$" "")
         suite-ns (or suite-ns default-suite-ns)
         tmp-main (core/tmp-dir!)]
     (core/with-pre-wrap fileset
       (let [namespaces (u/refine-namespaces fileset namespaces)]
         (core/empty-dir! tmp-main)
+        (info "Writing %s...\n" (str out-id ".cljs.edn"))
+        (spit (doto (io/file tmp-main (str out-id ".cljs.edn")) io/make-parents)
+              (pr-str {:require [suite-ns]}))
         (add-suite-ns! fileset tmp-main suite-ns namespaces)))))
 
 (deftask run-cljs-tests

--- a/src/crisptrutski/boot_cljs_test.clj
+++ b/src/crisptrutski/boot_cljs_test.clj
@@ -44,11 +44,9 @@
         out-path (u/relativize (.getPath tmp-main) (.getPath out-file))
         cljs     (u/cljs-files fileset)]
     (if (contains? (into #{} (map core/tmp-path) cljs) out-path)
-      (do (info "Using %s...\n" out-path)
-          fileset)
+      (info "Using %s...\n" out-path)
       (do (info "Writing %s...\n" out-path)
-          (spit out-file (gen-suite-ns suite-ns test-namespaces))
-          (-> fileset (core/add-source tmp-main) core/commit!)))))
+          (spit out-file (gen-suite-ns suite-ns test-namespaces))))))
 
 (deftask prep-cljs-tests
   "Prepare fileset to compile main entry point for the test suite."
@@ -70,7 +68,8 @@
         (info "Writing %s...\n" (str out-id ".cljs.edn"))
         (spit (doto (io/file tmp-main (str out-id ".cljs.edn")) io/make-parents)
               (pr-str {:require [suite-ns]}))
-        (add-suite-ns! fileset tmp-main suite-ns namespaces)))))
+        (add-suite-ns! fileset tmp-main suite-ns namespaces)
+        (-> fileset (core/add-source tmp-main) core/commit!)))))
 
 (deftask run-cljs-tests
   "Execute test reporter on compiled tests"


### PR DESCRIPTION
Brought across as standalone fix, although superseded in `0.3.0`

Closes #33
