### PR TITLE
Reverted to symlinks

### DIFF
--- a/src/crisptrutski/boot_cljs_test.clj
+++ b/src/crisptrutski/boot_cljs_test.clj
@@ -105,10 +105,9 @@
 (defn link-resources! [dir]
   (doseq [path (conj (boot/get-env :resource-paths) "node_modules")
           :let [f (io/file path)]
-          :when (.exists f)
-          :let [dest (doto (io/file dir path) (io/make-parents))]
-          :when (not (.exists dest))]
-    (file/hard-link f dest)))
+          :when (.exists f)]
+    (file/sym-link f (doto (io/file dir path)
+                       (io/make-parents)))))
 
 (defn run-tests! [ids js-env cljs-opts v exit? doo-opts doo-installed? verbosity fileset]
   (err/with-errors!


### PR DESCRIPTION
Hard symlinks are causing the tests to fail: https://circleci.com/gh/crisptrutski/boot-cljs-test/97 and break release 0.3.1.

```
Adding: ([org.clojure/clojurescript "1.7.228"] [adzerk/boot-cljs "1.7.228-2"] [doo "0.1.7"]) to :dependencies
Compiling ClojureScript...
• cljs_test/generated_test_suite.js

;; ======================================================================
;; Testing with Phantom:

                              java.lang.Thread.run                  Thread.java:  748
java.util.concurrent.ThreadPoolExecutor$Worker.run      ThreadPoolExecutor.java:  617
 java.util.concurrent.ThreadPoolExecutor.runWorker      ThreadPoolExecutor.java: 1142
               java.util.concurrent.FutureTask.run              FutureTask.java:  266
                                               ...                                   
               clojure.core/binding-conveyor-fn/fn                     core.clj: 1938
                                 boot.core/boot/fn                     core.clj: 1029
                               boot.core/run-tasks                     core.clj: 1019
      crisptrutski.boot-cljs-test/eval477/fn/fn/fn           boot_cljs_test.clj:  190
      crisptrutski.boot-cljs-test/eval297/fn/fn/fn           boot_cljs_test.clj:   97
                adzerk.boot-cljs/eval1394/fn/fn/fn                boot_cljs.clj:  135
                adzerk.boot-cljs/eval1446/fn/fn/fn                boot_cljs.clj:  208
      crisptrutski.boot-cljs-test/eval367/fn/fn/fn           boot_cljs_test.clj:  169
            crisptrutski.boot-cljs-test/run-tests!           boot_cljs_test.clj:  139
       crisptrutski.boot-cljs-test/link-resources!           boot_cljs_test.clj:  111
                               boot.file/hard-link                     file.clj:  165
                    java.nio.file.Files.createLink                   Files.java: 1086
      sun.nio.fs.UnixFileSystemProvider.createLink  UnixFileSystemProvider.java:  476
     sun.nio.fs.UnixException.rethrowAsIOException           UnixException.java:  102
   sun.nio.fs.UnixException.translateToIOException           UnixException.java:   91
java.nio.file.FileSystemException: /home/slacker/.boot/cache/tmp/home/slacker/Programming/sandbox/boot-cljs-test/example/6wb/u2qisy/cljs_test/resources -> resources: Operation not permitted
         file: "/home/slacker/.boot/cache/tmp/home/slacker/Programming/sandbox/boot-cljs-test/example/6wb/u2qisy/cljs_test/resources"
    otherFile: "resources"
       reason: "Operation not permitted"
       clojure.lang.ExceptionInfo: /home/slacker/.boot/cache/tmp/home/slacker/Programming/sandbox/boot-cljs-test/example/6wb/u2qisy/cljs_test/resources -> resources: Operation not permitted
    file: "/tmp/boot.user2271963516212482929.clj"
    line: 33
```