### PR TITLE
Wait for Karma to exit before allowing the JVM to exit.

### DIFF
--- a/src/crisptrutski/boot_cljs_test.clj
+++ b/src/crisptrutski/boot_cljs_test.clj
@@ -204,10 +204,13 @@
                       ((u/r doo.core/install!) [js-env] cljs-opts doo-opts)
                       (Thread/sleep 1000)))]
             (if karma?
-              ((u/r doo.core/karma-run!) doo-opts)
+              (let [proc ((u/r doo.core/karma-run!) doo-opts)]
+                (.waitFor proc)
+                (when-not (zero? (.exitValue proc))
+                  (err "Test failures signalled by Karma")))
               (let [{:keys [exit] :as result}
                     ((u/r doo.core/run-script) js-env cljs-opts doo-opts)]
-                (when (pos? exit)
+                (when-not (zero? exit)
                   (err result))))))))
     fileset))
 


### PR DESCRIPTION
doo's invocation of Karma is non-blocking and sets a JVM shutdown hook that
destroys the process on termination.  To actually get the outcome of the run,
we must wait for the process to complete before we exit.